### PR TITLE
Port Azure SDK patches to Consumption API v1.1.0

### DIFF
--- a/sdk/resourcemanager/consumption/armconsumption/models.go
+++ b/sdk/resourcemanager/consumption/armconsumption/models.go
@@ -2815,7 +2815,18 @@ type UsageDetailsClientListOptions struct {
 	// specifies a starting point to use for subsequent calls.
 	Skiptoken *string
 	// May be used to limit the number of results to the most recent N usageDetails.
-	Top *int32
+	Top       *int32
+	// According to the MS docs [1], modern customers with a Microsoft Customer Agreement (MCA) must
+	// use the `StartDate` and `EndDate` parameters to get the usage details for a specific date range.
+	//
+	// Unfortunately, these parameters are not included in the API spec file [2], so
+	// they must be manually added to the generated client.
+	//
+	// [1]: https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/manage-automation#get-usage-details-for-a-scope-during-specific-date-range
+	// [2]: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-11-01/consumption.json#L106-L147
+	//
+	StartDate *string
+	EndDate   *string
 }
 
 // UsageDetailsListResult - Result of listing usage details. It contains a list of available usage details in reverse chronological

--- a/sdk/resourcemanager/consumption/armconsumption/usagedetails_client.go
+++ b/sdk/resourcemanager/consumption/armconsumption/usagedetails_client.go
@@ -109,6 +109,13 @@ func (client *UsageDetailsClient) listCreateRequest(ctx context.Context, scope s
 	if options != nil && options.Top != nil {
 		reqQP.Set("$top", strconv.FormatInt(int64(*options.Top), 10))
 	}
+	// startDate and endDate support
+	if options != nil && options.StartDate != nil {
+		reqQP.Set("startDate", *options.StartDate)
+	}
+	if options != nil && options.EndDate != nil {
+		reqQP.Set("endDate", *options.EndDate)
+	}
 	reqQP.Set("api-version", "2021-10-01")
 	if options != nil && options.Metric != nil {
 		reqQP.Set("metric", string(*options.Metric))

--- a/sdk/resourcemanager/consumption/armconsumption/usagedetails_client.go
+++ b/sdk/resourcemanager/consumption/armconsumption/usagedetails_client.go
@@ -71,7 +71,35 @@ func (client *UsageDetailsClient) NewListPager(scope string, options *UsageDetai
 			if page == nil {
 				req, err = client.listCreateRequest(ctx, scope, options)
 			} else {
-				req, err = runtime.NewRequest(ctx, http.MethodGet, *page.NextLink)
+				//
+				// URL encodes `page.NextLink` to avoid 400 error.
+				//
+				// When there are more than 1000 usage details items, the
+				// Consumption SDK paginates the response. Each response page
+				// contains a 'next link' to the following page.
+				//
+				// The `$filter` query parameters contain a date range expression
+				// like the following:
+				//
+				// ```text
+				// properties/usageStart eq '2023-11-16' and properties/usageEnd eq '2023-11-16'
+				// ```
+				//
+				// Unfortunately, the Azure service adds the query parameter `$filter`
+				// value to the 'next link' without URL encoding it. Since one of the
+				// parameters, `$filter` contains space, it breaks the URL,
+				// causing the following parameters to get lost.
+				//
+				// **Possible solutions**
+				//
+				// As a workaround, we can encode the 'next link' URL to
+				// avoid the 400 error.
+				//					
+				nextLink, err := runtime.EncodeQueryParams(*page.NextLink)
+				if err != nil {
+					return UsageDetailsClientListResponse{}, err
+				}
+				req, err = runtime.NewRequest(ctx, http.MethodGet, nextLink)
 			}
 			if err != nil {
 				return UsageDetailsClientListResponse{}, err


### PR DESCRIPTION
This PR ports two patches to the Azure SDK to address the following problems:

- Add StartDate/EndDate parameters for MCA users
- URL encode 'next link' in multipage responses

## Add StartDate/EndDate parameters for MCA users

According to the [Microsoft docs](https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/manage-automation#get-usage-details-for-a-scope-during-specific-date-range), modern customers with a Microsoft Customer Agreement (MCA) must use the `StartDate` and `EndDate` query parameters to get the usage details for a specific date range.

Unfortunately, the [API spec](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/consumption/resource-manager/Microsoft.Consumption/stable/2023-11-01/consumption.json#L106-L147
) does include these query parameters, so we are manually adding them to the generated client.

If we don't add the query parameters, MCA users will get (many more) usage details items outside the intended time range.


## URL encode 'next link' in multipage responses

When there are more than 1000 usage details items, the Consumption API paginates the response. Each response page contains a 'next link' to the following page.

The `$filter` query parameters contain a date range expression like the following:

```
properties/usageStart eq '2023-11-16' and properties/usageEnd eq '2023-11-16'
```

Unfortunately, the Azure service adds the query parameters value to the 'next link' without URL-encoding them. Since one of the parameters, `$filter` contains space, it breaks the URL, causing the following query parameters to get lost causing the error.
